### PR TITLE
Bootstrapify

### DIFF
--- a/webapps/weathermap/index.jsp
+++ b/webapps/weathermap/index.jsp
@@ -23,7 +23,7 @@
    response.setHeader("Pragma","no-cache");
    response.setHeader("Expires","0"); 
 %>
-		<jsp:include page="/includes/header.jsp" flush="false">
+		<jsp:include page="/includes/bootstrap.jsp" flush="false">
 		  <jsp:param name="title" value="Display Weather Map" />
 		  <jsp:param name="breadcrumb" value="<%=breadcrumb1%>" />
 		</jsp:include>
@@ -83,7 +83,7 @@ getData();
 
 </p>
 
-    <jsp:include page="/includes/footer.jsp" flush="false" >
+    <jsp:include page="/includes/bootstrap-footer.jsp" flush="false" >
       <jsp:param name="location" value="weathermap" />
     </jsp:include>
     


### PR DESCRIPTION
The old header.jsp and footer.jsp are incompatible with the new Bootstrap way of doing things. This tiny change fixes it so that you don't get two headers in 15.0.x and Meridian.